### PR TITLE
Variable shadowing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "koi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koi"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 [dependencies]

--- a/src/build/x86/assemble.rs
+++ b/src/build/x86/assemble.rs
@@ -273,7 +273,13 @@ impl<'a> FunctionAssembler<'a> {
         // Emit if block; jump to next branch on false, or end if no branches
         self.evaluate_bool_and_cmp(&ifins.cond);
         self.push(Asm::Jz(next_label.clone().unwrap_or(end.clone())));
+
+        // Store current offset to go back to before evaluating else-if and else blocks.
+        // This ensures that stack slots are reused across all blocks.
+        // This is safe because all blocks are mutually exclusive.
+        let base_offset = self.cur_stack_offset();
         self.emit_block(&ifins.block);
+
         self.push(Asm::Jmp(end.clone()));
 
         // Emit else-if branches; each one consumes next_label and allocates the
@@ -291,12 +297,15 @@ impl<'a> FunctionAssembler<'a> {
             self.emit_ins_vec(&elseif.cond_ins);
             self.evaluate_bool_and_cmp(&elseif.cond);
             self.push(Asm::Jz(next_label.clone().unwrap_or(end.clone())));
+
+            self.set_stack_offset(base_offset);
             self.emit_block(&elseif.block);
             self.push(Asm::Jmp(end.clone()));
         }
 
         if let Some(elseblock) = &ifins.elseblock {
             self.push(Asm::Label(next_label.unwrap()));
+            self.set_stack_offset(base_offset);
             self.emit_block(elseblock);
         }
 
@@ -562,6 +571,16 @@ impl<'a> FunctionAssembler<'a> {
             offset: self.acc_offset,
             size: self.type_size(ty),
         })
+    }
+
+    /// Get current stack offset in bytes
+    fn cur_stack_offset(&self) -> usize {
+        self.acc_offset
+    }
+
+    /// Set stack offset. Used for scoping to reuse memory slots in mutually exclusive blocks.
+    fn set_stack_offset(&mut self, off: usize) {
+        self.acc_offset = off;
     }
 
     fn type_size(&self, ty: &IRTypeId) -> Size {

--- a/src/driver/tests/cases/var_shadow/var_shadow.koi
+++ b/src/driver/tests/cases/var_shadow/var_shadow.koi
@@ -1,0 +1,9 @@
+// Declaring a new variable with the same name inside an if block shadows
+// the outer variable. The outer variable must be unchanged after the block.
+func main() int {
+    x := 5
+    if x > 0 {
+        x := 9   // new declaration: shadows outer x
+    }
+    return x     // outer x = 5
+}

--- a/src/driver/tests/cases/var_shadow_assign/var_shadow_assign.koi
+++ b/src/driver/tests/cases/var_shadow_assign/var_shadow_assign.koi
@@ -1,0 +1,10 @@
+// Assigning (=) to an outer variable from inside an if block must update
+// the outer variable. This is distinct from shadowing (:= declares a new
+// inner variable; = writes to an existing one).
+func main() int {
+    x := 1
+    if x > 0 {
+        x = 7   // assignment to outer x
+    }
+    return x    // x = 7
+}

--- a/src/driver/tests/cases/var_shadow_branches/var_shadow_branches.koi
+++ b/src/driver/tests/cases/var_shadow_branches/var_shadow_branches.koi
@@ -1,0 +1,22 @@
+// Variables declared in if/elseif/else branches must be independent from
+// each other and must not interfere with outer variables. Each branch here
+// declares a uniquely-named inner variable and writes its value to an outer
+// accumulator. Only the taken branch runs, so result must equal that
+// branch's value.
+//
+// a=6: a<4 false, a<8 true → elseif taken → result = 2
+func main() int {
+    result := 0
+    a := 6
+    if a < 4 {
+        low := 1
+        result = low
+    } else if a < 8 {
+        mid := 2
+        result = mid
+    } else {
+        high := 3
+        result = high
+    }
+    return result
+}

--- a/src/driver/tests/cases/var_shadow_inner/var_shadow_inner.koi
+++ b/src/driver/tests/cases/var_shadow_inner/var_shadow_inner.koi
@@ -1,0 +1,12 @@
+// A variable declared inside an if block must be usable within that block.
+// Here the inner variable participates in an expression whose result is
+// written to an outer accumulator.
+func main() int {
+    result := 0
+    n := 4
+    if n > 2 {
+        extra := 3
+        result = n + extra
+    }
+    return result   // 4 + 3 = 7
+}

--- a/src/driver/tests/cases/var_shadow_reuse/var_shadow_reuse.koi
+++ b/src/driver/tests/cases/var_shadow_reuse/var_shadow_reuse.koi
@@ -1,0 +1,21 @@
+// The same variable name appears in each branch of an if/elseif/else.
+// Because branches are mutually exclusive scopes, each 'val' is an
+// independent variable. Only the taken branch's 'val' is ever live,
+// so result must equal the value assigned in the taken branch.
+//
+// a=6: elseif taken → val=20 → result=20
+func main() int {
+    result := 0
+    a := 6
+    if a < 4 {
+        val := 10
+        result = val
+    } else if a < 8 {
+        val := 20
+        result = val
+    } else {
+        val := 30
+        result = val
+    }
+    return result
+}

--- a/src/driver/tests/mod.rs
+++ b/src/driver/tests/mod.rs
@@ -381,6 +381,54 @@ fn test_bool_mixed_chain() {
     run_case_with_status("bool_mixed_chain", 1);
 }
 
+// --- variable shadowing and branch-local variables ---
+//
+// These tests cover three distinct scenarios:
+//
+// 1. Shadowing (:=): declaring a new variable with the same name as an outer
+//    one inside a block must not affect the outer variable.
+//
+// 2. Assignment (=): writing to an outer variable from inside a block must
+//    update the outer variable and remain visible after the block exits.
+//
+// 3. Stack slot allocation across branches: each branch of an if/elseif/else
+//    is a separate scope. Variables declared in different branches must not
+//    interfere. The "reuse" test uses the same variable name in every branch —
+//    since those scopes are mutually exclusive, each declaration is independent.
+
+#[test]
+fn test_var_shadow() {
+    // Inner x:=9 shadows outer x:=5; outer x must remain 5 after the block.
+    run_case_with_status("var_shadow", 5);
+}
+
+#[test]
+fn test_var_shadow_assign() {
+    // Inner x=7 (assignment) updates outer x:=1; outer x must be 7 afterward.
+    run_case_with_status("var_shadow_assign", 7);
+}
+
+#[test]
+fn test_var_shadow_inner() {
+    // Variable declared inside an if block is usable within that block.
+    // result = n(4) + extra(3) = 7.
+    run_case_with_status("var_shadow_inner", 7);
+}
+
+#[test]
+fn test_var_shadow_branches() {
+    // Uniquely-named inner variables in each branch; elseif taken → result=2.
+    run_case_with_status("var_shadow_branches", 2);
+}
+
+#[test]
+fn test_var_shadow_reuse() {
+    // Same variable name 'val' in each branch; elseif taken → val=20 → result=20.
+    // Guards against the IR emitter's flat scope causing the elseif branch to
+    // read the if-branch's unwritten stack slot.
+    run_case_with_status("var_shadow_reuse", 20);
+}
+
 // --- binary operand ordering ---
 //
 // These tests guard against the bug where rhs of a binary op was already in

--- a/src/typecheck/file_check.rs
+++ b/src/typecheck/file_check.rs
@@ -130,6 +130,7 @@ impl<'a> FileChecker<'a> {
 
     fn emit_func(&mut self, node: ast::FuncNode) -> Result<types::Decl, Report> {
         let meta = ast_node_to_meta(&node);
+        self.vars.clear(); // Make sure table is clean
 
         // Get declared function
         let func_type = self.get_symbol_type(&node.name)?.clone(); // moved later

--- a/src/typecheck/tests/checker_test.rs
+++ b/src/typecheck/tests/checker_test.rs
@@ -404,19 +404,6 @@ fn test_duplicate_symbol() {
 }
 
 #[test]
-fn test_param_shadowing_is_error() {
-    // declaring a local variable with the same name as a parameter should error
-    assert_error(
-        r#"
-        func f(a int) {
-            a := 1
-        }
-    "#,
-        "already declared",
-    );
-}
-
-#[test]
 fn test_extern_then_func_conflict() {
     // extern declaration followed by a concrete function with same name should be an error
     assert_error(

--- a/src/util/vartable.rs
+++ b/src/util/vartable.rs
@@ -31,12 +31,16 @@ impl<T> VarTable<T> {
     }
 
     /// Bind a name to T in the current scope. Return true if bind
-    /// is ok (name was not already declared).
+    /// is ok (name was not already declared in current scope).
     pub fn bind(&mut self, name: String, t: T) -> bool {
-        if self.get(&name).is_some() {
+        if self.cur_scope().get(&name).is_some() {
             return false;
         }
         self.scopes.last_mut().unwrap().insert(name, t).is_none()
+    }
+
+    fn cur_scope(&self) -> &HashMap<String, T> {
+        self.scopes.last().unwrap() // never empty
     }
 
     /// Look up a name starting from the innermost scope and iterating outwards.

--- a/todo.md
+++ b/todo.md
@@ -7,14 +7,6 @@
 
 ## Known bugs
 
-- Variable shadowing doesnt work
-    - Separate scopes should overlap stack memory when assembling
-- Function variable scope does not get dropped after an error is raised inside a function body
-    -   1. Declare `x := 0` in function `f`
-    -   2. Produce and error `io.println(b)` (not defined)
-    -   3. Declare `x := 0` in function `g` below
-    - Results in "`b` is not defined" _and_ "`x` is already defined"
-
 ## Language features
 
 - For-loop


### PR DESCRIPTION
* Variables now shadow others in higher scopes
* Fixed bug where VarTable was not cleared before function body
* Mutually exclusive scopes (if-elseif-else) reuse the same stack slots